### PR TITLE
fixed UTF-8 parsing problem

### DIFF
--- a/example_qt/qthighlight/highlighter.cpp
+++ b/example_qt/qthighlight/highlighter.cpp
@@ -190,7 +190,7 @@ void HGMarkdownHighlighter::parse()
     }
 
     QString content = document->toPlainText();
-    QByteArray ba = content.toLatin1();
+    QByteArray ba = content.toUtf8();
     char *content_cstring = strdup((char *)ba.data());
 
     if (workerThread != NULL)


### PR DESCRIPTION
We need to use UTF-8 here or otherwise characters like `»` and  `·` will irritate the highlighter.