### PR TITLE
require space after Atx heading hashes

### DIFF
--- a/pmh_grammar.leg
+++ b/pmh_grammar.leg
@@ -55,7 +55,7 @@ Plain =     Inlines
 
 AtxInline = !Newline !(Sp '#'* Sp Newline) Inline
 
-AtxStart =  < ( "######" | "#####" | "####" | "###" | "##" | "#" ) >
+AtxStart =  < ( "######" | "#####" | "####" | "###" | "##" | "#" ) Spacechar >
             { $$ = elem((pmh_element_type)(pmh_H1 + (strlen(yytext) - 1))); }
 
 AtxHeading = < s:AtxStart Sp ( AtxInline )+ (Sp '#'* Sp)? Newline >


### PR DESCRIPTION
Since `Sp` is defined as `Spacechar*`, right now a line like:

    #foo

Will be treated as a heading, which is uncommon enough for the CommonMark spec to specify as a mistake :) -- In practical terms, this makes editors with hashtags at the beginning of a line behave weirdly.